### PR TITLE
Add MIDI export

### DIFF
--- a/Readme.MD
+++ b/Readme.MD
@@ -1,10 +1,11 @@
 # Piano Sheet Processing Roadmap
 
 This project converts scanned classical piano sheet music into a machine-readable format.  
-The short-term goal is a backend-only pipeline that produces two artifacts:
+The short-term goal is a backend-only pipeline that produces three artifacts:
 
 1. **A MusicXML representation of the score.**  
 2. **A PDF rendering generated from that MusicXML.**
+3. **A MIDI file generated from that MusicXML.**
 
 Once this minimal pipeline works, we can extend it into a full Flask web application with an interactive music-sheet viewer.
 
@@ -53,14 +54,14 @@ Audiveris is a standalone Java application; install it separately and make sure 
 
 ### 2.1 Python helper script
 
-Instead of running Audiveris manually, you can call **`convert_sheet.py`** to automate the conversion **and** the PDF rendering:
+Instead of running Audiveris manually, you can call **`convert_sheet.py`** to automate the conversion **and** the PDF and MIDI rendering:
 
 ```bash
 python convert_sheet.py input.pdf -o output/
 ```
 
 The script accepts a single image/PDF *or* a directory of files and places the
-generated MusicXML and PDF files in the chosen output directory. Look for a file
+generated MusicXML, PDF, and MIDI files in the chosen output directory. Look for a file
 named `input.mxl` (or `input.xml`) inside `output/` or its subfolders.
 
 ## Troubleshooting

--- a/convert_sheet.py
+++ b/convert_sheet.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-"""Convert a scanned piano sheet into MusicXML and PDF.
+"""Convert a scanned piano sheet into MusicXML, PDF, and MIDI.
 
 This script uses Audiveris to perform optical music recognition on a single-page
-image or PDF and then uses music21 to generate a PDF rendering of the resulting
-MusicXML file.
+image or PDF and then uses music21 to generate PDF and MIDI renderings of the
+resulting MusicXML file.
 
 Example:
     python convert_sheet.py input.pdf -o output_dir
@@ -87,13 +87,22 @@ def render_pdf(xml_file: Path, output_file: Path) -> None:
         sys.exit(1)
 
 
+def render_midi(xml_file: Path, output_file: Path) -> None:
+    """Render ``xml_file`` to ``output_file`` as a MIDI file using music21."""
+    score = converter.parse(str(xml_file))
+    score.write("midi", fp=str(output_file))
+
+
 def process_files(files: Iterable[Path], output_dir: Path) -> None:
     for f in files:
         xml_file = run_audiveris(f, output_dir)
         pdf_file = output_dir / f"{xml_file.stem}.pdf"
         render_pdf(xml_file, pdf_file)
+        midi_file = output_dir / f"{xml_file.stem}.mid"
+        render_midi(xml_file, midi_file)
         print(f"Generated {xml_file}")
         print(f"Generated {pdf_file}")
+        print(f"Generated {midi_file}")
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- produce MIDI output when converting sheets
- mention MIDI in docs and script docstring

## Testing
- `python -m py_compile convert_sheet.py`
- `python convert_sheet.py -h` *(fails: ModuleNotFoundError: No module named 'music21')*